### PR TITLE
keep apk-tools up to date to prevent annoying messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ MAINTAINER Valerie Conklin <github.com/digivava>
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 
+# https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management#.22apk-tools_is_old.22
+RUN apk add --no-cache -U apk-tools@edge
+
 RUN apk --no-cache -U add \
   bash \
   curl \


### PR DESCRIPTION
The caveat to this is that apk-tools will now be tracking edge instead of stable, which may or may not be what you want. I leave it in your hands.