### PR TITLE
Revert "keep apk-tools up to date to prevent annoying messages"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ MAINTAINER Valerie Conklin <github.com/digivava>
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 
-# https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management#.22apk-tools_is_old.22
-RUN apk add --no-cache -U apk-tools@edge
-
 RUN apk --no-cache -U add \
   bash \
   curl \


### PR DESCRIPTION
Reverts digivava/valpine#2

`WARNING: The repository tag for world dependency 'apk-tools@edge' does not exist
ERROR: Not committing changes due to missing repository tags. Use --force-broken-world to override.
The command '/bin/sh -c apk add --no-cache -U apk-tools@edge' returned a non-zero code: 255`